### PR TITLE
Support Firefox

### DIFF
--- a/content.js
+++ b/content.js
@@ -51,7 +51,7 @@ function ProductItem(container) {
   loader.innerText = 'Loading...'
 
   return {
-    getProductUrl: () => productLink.getAttribute('href'),
+    getProductUrl: () => new URL(productLink.getAttribute('href'), window.location),
 
     isVisible: () => !container.closest('.aok-hidden, .a-hidden'),
 


### PR DESCRIPTION
It seems that the only incompatibility we had is that Firefox doesn't allow makes a request to a relative URL.
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#Content_script_requests_happen_in_the_context_of_extension_not_content_page