### PR TITLE
Add ID required for Firefox in Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,5 +37,10 @@
   },
   "icons": {
     "128": "img/sendhereplz-logo-128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "hello@sendhereplz.com"
+    }
   }
 }


### PR DESCRIPTION
https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/